### PR TITLE
Enable the interpolation of app id and version into appengine-web.xml

### DIFF
--- a/endpoints-skeleton-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/endpoints-skeleton-archetype/src/main/resources/archetype-resources/pom.xml
@@ -109,9 +109,17 @@
                 <configuration>
                     <webXml>${project.build.directory}/generated-sources/appengine-endpoints/WEB-INF/web.xml</webXml>
                     <webResources>
+                        <!-- in order to interpolate app name and version from pom into appengine-web.xml -->
+                        <resource>
+                            <directory>${basedir}/src/main/webapp/WEB-INF</directory>
+                            <filtering>true</filtering>
+                            <targetPath>WEB-INF</targetPath>
+                        </resource>
                         <resource>
                             <!-- this is relative to the pom.xml directory -->
                             <directory>${project.build.directory}/generated-sources/appengine-endpoints</directory>
+                            <!-- filtering is needed to interpolate app name from pom into the discovery files -->
+                            <filtering>true</filtering>
                             <!-- the list has a default value of ** -->
                             <includes>
                                 <include>WEB-INF/*.discovery</include>


### PR DESCRIPTION
Fixed this issue https://code.google.com/p/googleappengine/issues/detail?id=12645 I've reported yesterday. Maven pluging endpoints-skeleton-archetype does not interpolate app-id from pom into appengine-web.xml or the endpoint discovery files
