### PR TITLE
revert to 2.6 maven-war-plugin for m2e compatibility

### DIFF
--- a/appengine-standard-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/appengine-standard-archetype/src/main/resources/archetype-resources/pom.xml
@@ -124,7 +124,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>2.6</version>
         <configuration>
           <archiveClasses>true</archiveClasses>
           <webResources>


### PR DESCRIPTION
@lesv @akerekes This is high priority for Eclipse. We cannot use the standard archetype in Eclipse 4.5.2 without it. 
