### PR TITLE
application tag no longer required

### DIFF
--- a/appengine-standard-archetype/pom.xml
+++ b/appengine-standard-archetype/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
 
   <groupId>com.google.appengine.archetypes</groupId>
   <artifactId>appengine-standard-archetype</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>appengine-standard-archetype</name>

--- a/appengine-standard-archetype/src/main/resources/archetype-resources/README.md
+++ b/appengine-standard-archetype/src/main/resources/archetype-resources/README.md
@@ -10,8 +10,6 @@ This is a generated App Engine Standard Java application from the appengine-stan
 * [Gradle](https://gradle.org/gradle-download/) (optional)
 * [Google Cloud SDK](https://cloud.google.com/sdk/) (aka gcloud)
 
-WARNING: Java 7 is REQUIRED when you use JSP's locally.
-
 Initialize the Google Cloud SDK using:
 
     gcloud init

--- a/appengine-standard-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-standard-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/appengine-web.xml
@@ -3,7 +3,6 @@
 #set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>not-needed</application> <!-- no longer be required (in a week or so) -->
     <threadsafe>true</threadsafe>
     <system-properties>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>


### PR DESCRIPTION
1. Remove `<application>` tag from `appengine-web.xml`
2. Local JSP’s work w/ J8, so remove warning.
3. Bump the version for the archetype.
