### PR TITLE
Removing gcloud-maven-plugin from endpoints archetypes

### DIFF
--- a/endpoints-skeleton-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/endpoints-skeleton-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -55,8 +55,5 @@
     <requiredProperty key="ios-client-id">
       <defaultValue>replace this with your iOS client ID</defaultValue>
     </requiredProperty>
-    <requiredProperty key="gcloud-version">
-      <defaultValue>${gcloud.plugin.version}</defaultValue>
-    </requiredProperty>
   </requiredProperties>
 </archetype-descriptor>

--- a/endpoints-skeleton-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/endpoints-skeleton-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,6 @@
         <app.id>${application-id}</app.id>
         <app.version>1</app.version>
         <appengine.version>${appengine-version}</appengine.version>
-        <gcloud.plugin.version>${gcloud-version}</gcloud.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
@@ -141,14 +140,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-              <groupId>com.google.appengine</groupId>
-              <artifactId>gcloud-maven-plugin</artifactId>
-              <version>${gcloud.plugin.version}</version>
-              <configuration>
-                <set_default>true</set_default>
-              </configuration>
             </plugin>
         </plugins>
     </build>

--- a/endpoints-skeleton-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/endpoints-skeleton-archetype/src/test/resources/projects/basic/archetype.properties
@@ -4,7 +4,6 @@ version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
 appengine-version=1.9.38
-gcloud-version=2.0.9.111.v20160527
 application-id=your-app-id
 web-client-id=replace this with your web client ID
 android-client-id=replace this with your Android client ID

--- a/hello-endpoints-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/hello-endpoints-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -55,8 +55,5 @@
     <requiredProperty key="ios-client-id">
       <defaultValue>replace this with your iOS client ID</defaultValue>
     </requiredProperty>
-    <requiredProperty key="gcloud-version">
-      <defaultValue>${gcloud.plugin.version}</defaultValue>
-    </requiredProperty>
   </requiredProperties>
 </archetype-descriptor>

--- a/hello-endpoints-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/hello-endpoints-archetype/src/main/resources/archetype-resources/pom.xml
@@ -12,7 +12,6 @@
         <app.id>${application-id}</app.id>
         <app.version>1</app.version>
         <appengine.version>${appengine-version}</appengine.version>
-        <gcloud.plugin.version>${gcloud-version}</gcloud.plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -143,14 +142,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-              <groupId>com.google.appengine</groupId>
-              <artifactId>gcloud-maven-plugin</artifactId>
-              <version>${gcloud.plugin.version}</version>
-              <configuration>
-                <set_default>true</set_default>
-              </configuration>
             </plugin>
         </plugins>
     </build>

--- a/hello-endpoints-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/hello-endpoints-archetype/src/test/resources/projects/basic/archetype.properties
@@ -4,7 +4,6 @@ version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
 appengine-version=1.9.38
-gcloud-version=2.0.9.111.v20160527
 application-id=your-app-id
 web-client-id=replace this with your web client ID
 android-client-id=replace this with your Android client ID


### PR DESCRIPTION
In this PR I removed gcloud-maven plugin version from being required in the following archetypes:

- endpoints-skeleton-arhcetype
- hello-endpoints-archetype

The plugin isn't necessary for app deployment to GAE Standard or app local testing.