### PR TITLE
Temporary fix for Endpoints Archetypes

### DIFF
--- a/endpoints-skeleton-archetype/src/main/resources/archetype-resources/README.md
+++ b/endpoints-skeleton-archetype/src/main/resources/archetype-resources/README.md
@@ -90,6 +90,12 @@ provided [here][9].
 
     `gradle appengineDeploy`
 
+## Known issues
+
+There's a [bug][13] where `<version>1</version>` is required in the
+[appengine-web.xml](src/main/webapp/WEB-INF/appengine-web.xml) to run
+this sample locally. This will become optional in the near future.
+
 
 [1]: https://cloud.google.com/appengine/docs/java/
 [2]: http://java.com/en/
@@ -103,3 +109,4 @@ provided [here][9].
 [10]: https://github.com/GoogleCloudPlatform/endpoints-framework-maven-plugin
 [11]: https://github.com/GoogleCloudPlatform/endpoints-framework-gradle-plugin
 [12]: https://cloud.google.com/endpoints/docs/authenticating-users-frameworks
+[13]: https://github.com/cloudendpoints/endpoints-java/issues/43

--- a/endpoints-skeleton-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/endpoints-skeleton-archetype/src/main/resources/archetype-resources/build.gradle
@@ -29,9 +29,6 @@ buildscript {    // Configuration for building
 }
 
 repositories {   // repositories for Jar's you access in your code
-  maven {
-    url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT Repository (if needed)
-  }
   mavenCentral()
   jcenter()
 }

--- a/endpoints-skeleton-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/endpoints-skeleton-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
     <threadsafe>true</threadsafe>
+    <version>1</version>
 
     <system-properties>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/hello-endpoints-archetype/src/main/resources/archetype-resources/README.md
+++ b/hello-endpoints-archetype/src/main/resources/archetype-resources/README.md
@@ -99,6 +99,13 @@ provided [here][9].
 
     `gradle appengineDeploy`
 
+## Known issues
+
+There's a [bug][13] where `<version>1</version>` is required in the
+[appengine-web.xml](src/main/webapp/WEB-INF/appengine-web.xml) to run
+this sample locally. This will become optional in the near future.
+
+
 [1]: https://cloud.google.com/appengine/docs/java/
 [2]: http://java.com/en/
 [3]: https://cloud.google.com/appengine/docs/java/endpoints/
@@ -111,3 +118,4 @@ provided [here][9].
 [10]: https://github.com/GoogleCloudPlatform/endpoints-framework-maven-plugin
 [11]: https://github.com/GoogleCloudPlatform/endpoints-framework-gradle-plugin
 [12]: https://cloud.google.com/endpoints/docs/authenticating-users-frameworks
+[13]: https://github.com/cloudendpoints/endpoints-java/issues/43

--- a/hello-endpoints-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/hello-endpoints-archetype/src/main/resources/archetype-resources/build.gradle
@@ -30,9 +30,6 @@ buildscript {    // Configuration for building
 }
 
 repositories {   // repositories for Jar's you access in your code
-  maven {
-    url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT Repository (if needed)
-  }
   mavenCentral()
   jcenter()
 }

--- a/hello-endpoints-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/hello-endpoints-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-   <threadsafe>true</threadsafe>
+    <threadsafe>true</threadsafe>
+    <version>1</version>
 
     <system-properties>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>


### PR DESCRIPTION
This is a temporary fix for a [known bug](https://github.com/cloudendpoints/endpoints-java/issues/43) when running Endpoints Frameworks archetypes locally. An optional value `version` needs to be defined in the `appengine-web.xml` for the sample to run. Added a mention in the `README.md` of the generated archetype.

This PR also includes clean up of the `build.gradle` file for each endpoints archetype.

Archetypes effected:
* endpoints-skeleton-archetype
* hello-endpoints-archetype