### PR TITLE
typo's in readme

### DIFF
--- a/appengine-skeleton-archetype/pom.xml
+++ b/appengine-skeleton-archetype/pom.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <project>
   <groupId>com.google.appengine.archetypes</groupId>
   <artifactId>appengine-skeleton-archetype</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <packaging>maven-archetype</packaging>
 
   <name>appengine-skeleton-archetype</name>

--- a/appengine-skeleton-archetype/src/main/resources/archetype-resources/README.md
+++ b/appengine-skeleton-archetype/src/main/resources/archetype-resources/README.md
@@ -25,7 +25,7 @@ $pound$pound$pound Running locally
 #if ( $CloudSDK_Tooling == "true" )
     mvn appengine:run
 #else
-    mvn appengine:devappserver
+    mvn appengine:devserver
 #end
 
 $pound$pound$pound Deploying

--- a/appengine-standard-archetype/pom.xml
+++ b/appengine-standard-archetype/pom.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <project>
   <groupId>com.google.appengine.archetypes</groupId>
   <artifactId>appengine-standard-archetype</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>maven-archetype</packaging>
 
   <name>appengine-standard-archetype</name>

--- a/appengine-standard-archetype/src/main/resources/archetype-resources/README.md
+++ b/appengine-standard-archetype/src/main/resources/archetype-resources/README.md
@@ -25,7 +25,7 @@ $pound$pound$pound Running locally
 #if ( $CloudSDK_Tooling == "true" )
     mvn appengine:run
 #else
-    mvn appengine:devappserver
+    mvn appengine:devserver
 #end
 
 $pound$pound$pound Deploying

--- a/guestbook-archetype/pom.xml
+++ b/guestbook-archetype/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
 
   <groupId>com.google.appengine.archetypes</groupId>
   <artifactId>guestbook-archetype</artifactId>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <packaging>maven-archetype</packaging>
 
   <name>guestbook-archetype</name>

--- a/guestbook-archetype/src/main/resources/archetype-resources/README.md
+++ b/guestbook-archetype/src/main/resources/archetype-resources/README.md
@@ -24,7 +24,7 @@ $pound$pound$pound Running locally
 #if ( $CloudSDK_Tooling == "true" )
     mvn appengine:run
 #else
-    mvn appengine:devappserver
+    mvn appengine:devserver
 #end
 
 $pound$pound$pound Deploying


### PR DESCRIPTION
1. for GAE Java Plugin was trying to do appengine:devappserver instead
of app engine:devserver
2. bump versions

appengine-skeleton-archetype
appengine-standard-archetype
guestbook-archetype